### PR TITLE
Adding support for custom auth routes

### DIFF
--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -6,6 +6,8 @@ export default {
     refreshTokenExpiresIn : '1d',
     cookieResponse: false,
     refreshTokenRotation: false,
+    refreshRoute: undefined,
+    authRoute: undefined
   },
   validator() {},
 };

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -30,9 +30,12 @@ function calculateMaxAge(param) {
 function auth({ strapi }) {
   const config = strapi.config.get(`plugin::${PLUGIN_ID}`);
 
+  const authRoute = config.authRoute ?? '/api/auth/local'
+  const refreshRoute = config.refreshRoute ?? '/api/auth/local/refresh'
+
   return async (ctx, next) => {
     await next();
-    if (ctx.request.method === 'POST' && ctx.request.path === '/api/auth/local') {
+    if (ctx.request.method === 'POST' && ctx.request.path === authRoute) {
       const requestRefresh = ctx.request.body?.requestRefresh || config.requestRefreshOnAll;
       if (ctx.response.body && ctx.response.message === 'OK' && requestRefresh) {
         const refreshEntry = await strapi
@@ -61,7 +64,7 @@ function auth({ strapi }) {
           };
         }
       }
-    } else if (ctx.request.method === 'POST' && ctx.request.path === '/api/auth/local/refresh') {
+    } else if (ctx.request.method === 'POST' && ctx.request.path === refreshRoute) {
       const refreshToken = ctx.request.body?.refreshToken;
       if (refreshToken) {
         try {


### PR DESCRIPTION
Added refreshRoute and authRoute which correlate with new config entries, if they don't exist fall back to the current. 

Proposing this change because I have a custom auth that doesn't go to /auth/local. Should still work with the middleware but the route just needs to be configurable.